### PR TITLE
Podcast follow-up: chapter markers (CHAP + sidecar JSON)

### DIFF
--- a/podcast/seven-habits.chapters.json
+++ b/podcast/seven-habits.chapters.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.2.0",
+  "chapters": [
+    {
+      "startTime": 0.0,
+      "title": "Foundations"
+    },
+    {
+      "startTime": 1137.8000000000004,
+      "title": "Habit 1: Be Proactive"
+    },
+    {
+      "startTime": 2251.2799999999997,
+      "title": "Habit 2: Begin with the End in Mind"
+    },
+    {
+      "startTime": 3117.319999999999,
+      "title": "Habit 3: Put First Things First"
+    },
+    {
+      "startTime": 4289.239999999998,
+      "title": "Habit 4: Win-Win, or No Deal"
+    },
+    {
+      "startTime": 5901.279999999995,
+      "title": "Habit 5: Seek First to Understand"
+    },
+    {
+      "startTime": 6727.599999999994,
+      "title": "Habit 6: Synergize"
+    },
+    {
+      "startTime": 7383.959999999994,
+      "title": "Habit 7: Sharpen the Saw"
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to merged #22. Adds two ways for podcast clients to surface chapter navigation in the 7-habits episode:

## Two commits

**1. ID3 CHAP chapter markers in the MP3** (universal support)

Embedded 8 chapter markers via mutagen so Overcast / Apple Podcasts / Pocket Casts / Castro all show clickable navigation. Adds ~65 KB to the file; still 60.9 MB total.

**2. Podcasting 2.0 chapters.json sidecar**

Same 8 chapter boundaries exposed as a JSON sidecar at `podcast/seven-habits.chapters.json` for clients that prefer the [Podcasting 2.0 chapters spec](https://github.com/Podcastindex-org/podcast-namespace/blob/main/proposal-docs/chapters/jsonChapters.md). Spec version 1.2.0.

Belt + suspenders — covers both old (ID3) and new (Podcasting 2.0) chapter UX.

## Chapters

| Time | Chapter |
|---|---|
| 00:00 | Foundations |
| 18:57 | Habit 1: Be Proactive |
| 37:31 | Habit 2: Begin with the End in Mind |
| 51:57 | Habit 3: Put First Things First |
| 1:11:29 | Habit 4: Win-Win, or No Deal |
| 1:38:21 | Habit 5: Seek First to Understand |
| 1:52:07 | Habit 6: Synergize |
| 2:03:03 | Habit 7: Sharpen the Saw |

## Companion PR

The blog repo needs a small RSS feed update to reference the sidecar via the `<podcast:chapters>` tag. PR linked below.

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chapter metadata support for podcast episodes. Users can now navigate between chapters within episodes using chapter titles and precise timestamps. This feature improves content organization, enables easier navigation and discovery within podcast playback, and makes it simpler to jump to specific segments of interest.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/idvorkin/blob/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->